### PR TITLE
Adding Identifier for Mock Data

### DIFF
--- a/bgs.gemspec
+++ b/bgs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name          = 'bgs_ext'
-  gem.version       = '0.14.9'
+  gem.version       = '0.15.0'
   gem.summary       = 'Thin wrapper on top of savon to talk with BGS'
   gem.description   = 'Thin wrapper on top of savon to talk with BGS for external BGS consumers'
   gem.license       = 'CC0' # This work is a work of the US Federal Government,

--- a/lib/bgs/services/person.rb
+++ b/lib/bgs/services/person.rb
@@ -29,8 +29,8 @@ module BGS
       response.body[:find_person_by_file_number_response][:person_dto]
     end
 
-    def find_person_by_ptcpnt_id(participant_id)
-      response = request(:find_person_by_ptcpnt_id, "ptcpntId": participant_id)
+    def find_person_by_ptcpnt_id(participant_id, ssn = nil)
+      response = request(:find_person_by_ptcpnt_id, { "ptcpntId": participant_id }, ssn)
       response.body[:find_person_by_ptcpnt_id_response][:person_dto]
     end
 


### PR DESCRIPTION
This PR adds an identifier to the people service `find_person_by_ptcpnt_id` method so that it can be used for mock data services with our `vets-api-mockdata` repo.  

Original ticket here: https://github.com/department-of-veterans-affairs/va.gov-team/issues/14593

This PR also updates the gem version.  