### PR TITLE
API-3272: Small edits to accommodate vets-api consuming this logic

### DIFF
--- a/lib/bgs/services/contention.rb
+++ b/lib/bgs/services/contention.rb
@@ -35,6 +35,7 @@ module BGS
       contentions = options[:contentions].map do |contention|
         {
           'clmId': contention[:clm_id],
+          'cntntnId': contention[:cntntn_id],
           'specialIssues': contention[:special_issues].map do |special_issue|
             { 'spisTc': special_issue[:spis_tc] }
           end

--- a/spec/bgs/services/contention_spec.rb
+++ b/spec/bgs/services/contention_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'bgs'
-require 'byebug'
 
 describe BGS::ContentionService do
   let(:service) do
@@ -15,6 +14,31 @@ describe BGS::ContentionService do
     VCR.use_cassette('contention/find_contentions_by_ptcpnt_id') do
       response = service.contention.find_contentions_by_ptcpnt_id('600036156')
       expect(response[:benefit_claims].count).to eq(289)
+
+      first_claim = response[:benefit_claims].first
+      expect(first_claim[:call_id]).to eq('17')
+      expect(first_claim[:jrn_lctn_id]).to eq('281')
+      expect(first_claim[:jrn_obj_id]).to eq('EBENEFITS  - CEST')
+      expect(first_claim[:jrn_stt_tc]).to eq('I')
+      expect(first_claim[:jrn_user_id]).to eq('VAEBENEFITS')
+      expect(first_claim[:name]).to eq('BenefitClaim')
+      expect(first_claim[:row_cnt]).to eq('289')
+      expect(first_claim[:row_id]).to eq('1736')
+      expect(first_claim[:bnft_clm_tc]).to eq('400SUPP')
+      expect(first_claim[:bnft_clm_tn]).to eq('eBenefits 526EZ-Supplemental (400)')
+      expect(first_claim[:clm_id]).to eq('600100330')
+      expect(first_claim[:clm_suspns_cd]).to eq('056')
+      expect(first_claim[:lc_stt_rsn_tc]).to eq('CAN')
+      expect(first_claim[:lc_stt_rsn_tn]).to eq('Cancelled')
+      expect(first_claim[:lctn_id]).to eq('322')
+      expect(first_claim[:non_med_clm_desc]).to eq('eBenefits 526EZ-Supplemental (400)')
+      expect(first_claim[:notes_ind]).to eq('1')
+      expect(first_claim[:prirty]).to eq('0')
+      expect(first_claim[:ptcpnt_id_clmnt]).to eq('600036156')
+      expect(first_claim[:ptcpnt_id_vet]).to eq('600036156')
+      expect(first_claim[:ptcpnt_suspns_id]).to eq('13381347')
+      expect(first_claim[:soj_lctn_id]).to eq('347')
+      expect(first_claim[:suspns_rsn_txt]).to eq('Cancelled')
     end
   end
 


### PR DESCRIPTION
## Description of change
Adds contention_id mapping to allow that to be passed in from the consumer.

## Original issue(s)
https://vajira.max.gov/browse/API-3272

## Things to know about this PR
specs