### PR TITLE
add logger option to pass to savon

### DIFF
--- a/bgs.gemspec
+++ b/bgs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name          = 'bgs_ext'
-  gem.version       = '0.18.0'
+  gem.version       = '0.19.0'
   gem.summary       = 'Thin wrapper on top of savon to talk with BGS'
   gem.description   = 'Thin wrapper on top of savon to talk with BGS for external BGS consumers'
   gem.license       = 'CC0' # This work is a work of the US Federal Government,

--- a/lib/bgs.rb
+++ b/lib/bgs.rb
@@ -25,7 +25,7 @@ module BGS
     attr_accessor :client_ip, :application, :client_username,
                   :env, :client_station_id, :jumpbox_url,
                   :ssl_cert_file, :ssl_cert_key_file, :ssl_ca_cert,
-                  :log, :mock_responses, :forward_proxy_url,
+                  :log, :logger, :mock_responses, :forward_proxy_url,
                   :mock_response_location, :external_uid, :external_key,
                   :ssl_verify_mode
 

--- a/lib/bgs/base.rb
+++ b/lib/bgs/base.rb
@@ -27,13 +27,14 @@ module BGS
     attr_accessor :mock_responses
     def initialize(application:, forward_proxy_url: nil, jumpbox_url: nil,
                    env:, client_ip:, client_station_id:, client_username:, log: false,
-                   ssl_cert_file: nil, ssl_cert_key_file: nil, ssl_ca_cert: nil,
+                   logger: nil, ssl_cert_file: nil, ssl_cert_key_file: nil, ssl_ca_cert: nil,
                    external_uid: nil, external_key: nil, mock_responses: false, ssl_verify_mode: 'peer')
       @application = application
       @client_ip = client_ip
       @client_station_id = client_station_id
       @client_username = client_username
       @log = log
+      @logger = logger
       @env = env
       @forward_proxy_url = forward_proxy_url
       @jumpbox_url = jumpbox_url
@@ -144,6 +145,7 @@ module BGS
         wsdl: wsdl,
         soap_header: header,
         log: @log,
+        logger: @logger,
         ssl_cert_key_file: @ssl_cert_key_file,
         headers: headers,
         ssl_cert_file: @ssl_cert_file,

--- a/lib/bgs/services.rb
+++ b/lib/bgs/services.rb
@@ -68,6 +68,7 @@ module BGS
                   forward_proxy_url: configuration.forward_proxy_url,
                   jumpbox_url: configuration.jumpbox_url,
                   log: configuration.log,
+                  logger: configuration.logger,
                   external_uid: external_uid,
                   external_key: external_key,
                   mock_responses: configuration.mock_responses,

--- a/spec/bgs/base_spec.rb
+++ b/spec/bgs/base_spec.rb
@@ -16,7 +16,7 @@ describe BGS::Base do
       jumpbox_url: nil,
       external_uid: 'mytestuid',
       external_key: 'mytestkey',
-      log: false # don't post log data into test output
+      log: true
     )
   end
 

--- a/spec/bgs/base_spec.rb
+++ b/spec/bgs/base_spec.rb
@@ -176,15 +176,16 @@ describe BGS::Base do
       @logger = Logger.new(@log_out)
       BGS.configure do |config|
         @old_logger = config.logger
-        @old_log_bool = config.log
+        @old_log_enabled = config.log
         config.logger = @logger
         config.log = true
       end
     end
+
     after(:all) do
       BGS.configure do |config|
         config.logger = @old_logger
-        config.log =  @old_log_bool
+        config.log =  @old_log_enabled
       end
     end
 

--- a/spec/bgs/base_spec.rb
+++ b/spec/bgs/base_spec.rb
@@ -169,6 +169,45 @@ describe BGS::Base do
       expect(base.send(:client).wsdl.endpoint).to eq('http://localhost:1337/TestBaseBean/TestBase')
     end
   end
+
+  context 'with a provided logger' do
+    before(:all) do
+      @log_out = StringIO.new
+      @logger = Logger.new(@log_out)
+      BGS.configure do |config|
+        @old_logger = config.logger
+        @old_log_bool = config.log
+        config.logger = @logger
+        config.log = true
+      end
+    end
+    after(:all) do
+      BGS.configure do |config|
+        config.logger = @old_logger
+        config.log =  @old_log_bool
+      end
+    end
+
+    before do
+      @log_out.truncate(0)
+    end
+
+    it 'should log to provided logger' do
+      service = BGS::Services.new(
+        external_uid: 'something',
+        external_key: 'something'
+      )
+
+      # arbitrary endpoint in order for debug and info messages to be generated
+      VCR.use_cassette('award/find_award_by_file_number') do
+        response = service.awards.find_award_by_file_number('123345566', '999999999')
+        expect(response[:gross_amt]).to eq('0.0')
+      end
+      expect(@log_out.string).not_to be_empty
+      expect(@log_out.string).to match(/D, \[.+\] DEBUG -- /)
+      expect(@log_out.string).to match(/I, \[.+\]  INFO -- /)
+    end
+  end
 end
 # rubocop:enable Metrics/BlockLength
 

--- a/spec/bgs/base_spec.rb
+++ b/spec/bgs/base_spec.rb
@@ -16,7 +16,7 @@ describe BGS::Base do
       jumpbox_url: nil,
       external_uid: 'mytestuid',
       external_key: 'mytestkey',
-      log: true
+      log: false # don't post log data into test output
     )
   end
 

--- a/spec/bgs/services/awards_spec.rb
+++ b/spec/bgs/services/awards_spec.rb
@@ -13,25 +13,6 @@ describe BGS::AwardWebService do
     )
   end
 
-  # this should be in base_spec somehow
-  it 'should log to provided logger' do
-    out = StringIO.new
-    log = Logger.new(out)
-    old_logger = nil
-    BGS.configure do |config|
-      old_logger = config.logger
-      config.logger = log
-    end
-    VCR.use_cassette('award/find_award_by_file_number') do
-      response = service.awards.find_award_by_file_number(file_number, ssn)
-      expect(response[:gross_amt]).to eq('0.0')
-    end
-    BGS.configure do |config|
-      config.logger = old_logger
-    end
-    expect(out.string).not_to be_empty
-  end
-
   it 'should find award by file number' do
     VCR.use_cassette('award/find_award_by_file_number') do
       response = service.awards.find_award_by_file_number(file_number, ssn)

--- a/spec/bgs/services/awards_spec.rb
+++ b/spec/bgs/services/awards_spec.rb
@@ -13,6 +13,25 @@ describe BGS::AwardWebService do
     )
   end
 
+  # this should be in base_spec somehow
+  it 'should log to provided logger' do
+    out = StringIO.new
+    log = Logger.new(out)
+    old_logger = nil
+    BGS.configure do |config|
+      old_logger = config.logger
+      config.logger = log
+    end
+    VCR.use_cassette('award/find_award_by_file_number') do
+      response = service.awards.find_award_by_file_number(file_number, ssn)
+      expect(response[:gross_amt]).to eq('0.0')
+    end
+    BGS.configure do |config|
+      config.logger = old_logger
+    end
+    expect(out.string).not_to be_empty
+  end
+
   it 'should find award by file number' do
     VCR.use_cassette('award/find_award_by_file_number') do
       response = service.awards.find_award_by_file_number(file_number, ssn)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,7 +29,7 @@ BGS.configure do |config|
   config.external_key = 'lighthouse-vets-api'
   config.forward_proxy_url = 'https://localhost:4447'
   config.ssl_verify_mode = 'none'
-  # config.log = true
+  config.log = false # false to reduce test output noise
 end
 
 VCR.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,4 +47,6 @@ RSpec.configure do |config|
   end
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  config.filter_run_when_matching :focus
 end


### PR DESCRIPTION
Savon supports a `logger` configuration to determine where the log output should go.  Without it, it always prints log messages to stdout and can dirty up console output.

## Description of change
* added logger configuration to pass along to Savon
* allow specs to use `focus`
* change log setting in spec helper to turn off some logging noise in output