### PR TITLE
API-6461: Corporate Update BGS service implementation was incorrect

### DIFF
--- a/lib/bgs/services/corporate_update.rb
+++ b/lib/bgs/services/corporate_update.rb
@@ -12,11 +12,15 @@ module BGS
       'corporate_update'
     end
 
+    def bean_name
+      'CorporateUpdateServiceBean'
+    end
+
     # update a POA relationship
     def update_poa_access(participant_id:, poa_code:, allow_poa_access: 'y', allow_poa_c_add: 'y')
       response = request(
         :update_poa_access,
-        "updatePoaAccess": {
+        {
           "ptcpntId": participant_id,
           "poa": poa_code,
           "allowPoaAccess": allow_poa_access,

--- a/spec/bgs/services/corporate_update_spec.rb
+++ b/spec/bgs/services/corporate_update_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'bgs'
+
+describe BGS::CorporateUpdateWebService do
+  let(:poa_code) { '091' }
+  let(:participant_id) { '600043201' }
+  let(:service) do
+    BGS::Services.new(
+      external_uid: 'something',
+      external_key: 'something'
+    )
+  end
+
+  xit 'updates poa access' do
+    pending('Receiving tuxedo error when hitting endpoint')
+    
+    VCR.use_cassette('corporate_update/update_poa_access') do
+      service.corporate_update.update_poa_access(
+        participant_id: participant_id,
+        poa_code: poa_code
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
URL being generated was incorrect. Possible this has simply changed since this method was implemented. Hard to tell since there are no existing specs for this service.
The payload being sent was also incorrect and needed to be modified.

## Original issue(s)
https://vajira.max.gov/browse/API-6461

## Things to know about this PR
The spec I wrote for this is currently being skipped due to the following error in BGS's Linktest environment:
`TuxedoServiceFoundButWrongApp`