### PR TITLE
Removing Address Fields from Validation [Benefit Service]

### DIFF
--- a/bgs.gemspec
+++ b/bgs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name          = 'bgs_ext'
-  gem.version       = '0.21.1'
+  gem.version       = '0.21.2'
   gem.summary       = 'Thin wrapper on top of savon to talk with BGS'
   gem.description   = 'Thin wrapper on top of savon to talk with BGS for external BGS consumers'
   gem.license       = 'CC0' # This work is a work of the US Federal Government,

--- a/lib/bgs/services/benefit.rb
+++ b/lib/bgs/services/benefit.rb
@@ -161,9 +161,6 @@ module BGS
         end_product_code
         first_name
         last_name
-        city
-        state
-        postal_code
         country
         disposition
         section_unit_no


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
During testing, it was discovered that city, state, and postal code are currently being validated against when inserting a claim.  However, these fields are empty when the address is a military or foreign address.  This PR removes city, state, and postal code from the list of required fields.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#29440

## Things to know about this PR
<!--
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
This PR also bumps the gem version.