### PR TITLE
[API-15184] - ClaimsApi - insertIntentToFile allow optional 'claimant_ssn' attribute

### DIFF
--- a/lib/bgs.rb
+++ b/lib/bgs.rb
@@ -28,7 +28,5 @@ module BGS
                   :log, :logger, :mock_responses, :forward_proxy_url,
                   :mock_response_location, :external_uid, :external_key,
                   :ssl_verify_mode
-
-    def initialize; end
   end
 end

--- a/lib/bgs/services/intent_to_file.rb
+++ b/lib/bgs/services/intent_to_file.rb
@@ -25,19 +25,22 @@ module BGS
 
     def insert_intent_to_file(options)
       validate_required_keys(required_insert_intent_to_file_fields, options, __method__.to_s)
+      missing_claimant_attributes!(options: options)
+
+      request_body = {
+        itfTypeCd: options[:intent_to_file_type_code],
+        ptcpntVetId: options[:participant_vet_id],
+        rcvdDt: options[:received_date],
+        signtrInd: options[:signature_indicated],
+        submtrApplcnTypeCd: options[:submitter_application_icn_type_code]
+      }
+      request_body[:ptcpntClmantId] = options[:participant_claimant_id] if options.key?(:participant_claimant_id)
+      request_body[:clmantSsn] = options[:claimant_ssn] if options.key?(:claimant_ssn)
 
       response = request(
         :insert_intent_to_file,
         {
-          intentToFileDTO: {
-            itfTypeCd: options[:intent_to_file_type_code],
-            ptcpntClmantId: options[:participant_claimant_id],
-            ptcpntVetId: options[:participant_vet_id],
-            rcvdDt: options[:received_date],
-            signtrInd: options[:signature_indicated],
-            submtrApplcnTypeCd: options[:submitter_application_icn_type_code]
-
-          }
+          intentToFileDTO: request_body
         },
         options[:ssn]
       )
@@ -80,7 +83,6 @@ module BGS
     def required_insert_intent_to_file_fields
       %i[
         intent_to_file_type_code
-        participant_claimant_id
         participant_vet_id
         received_date
         submitter_application_icn_type_code
@@ -94,6 +96,13 @@ module BGS
         received_date
         submitter_application_icn_type_code
       ]
+    end
+
+    def missing_claimant_attributes!(options:)
+      return if options.key?(:participant_claimant_id)
+      return if options.key?(:claimant_ssn)
+
+      raise(ArgumentError, "Must include either 'participant_claimant_id' or 'claimant_ssn'")
     end
   end
 end

--- a/spec/bgs/services/intent_to_file_spec.rb
+++ b/spec/bgs/services/intent_to_file_spec.rb
@@ -148,4 +148,92 @@ describe BGS::IntentToFileWebService do
       end
     end
   end
+
+  context 'validating required fields' do
+    context "for 'insert_intent_to_file'" do
+      required_fields = %i[
+        intent_to_file_type_code
+        participant_vet_id
+        received_date
+        submitter_application_icn_type_code
+      ]
+
+      hash = {
+        intent_to_file_type_code: 'hello_world',
+        participant_vet_id: 'hello_world',
+        received_date: 'hello_world',
+        submitter_application_icn_type_code: 'hello_world'
+      }
+
+      context 'when a required field is missing' do
+        required_fields.each do |required_field|
+          it "raises an 'ArgumentError' for missing required field" do
+            options = hash.clone
+            options.delete(required_field)
+
+            expect { service.intent_to_file.insert_intent_to_file(options) }
+              .to raise_error(
+                ArgumentError,
+                "#{required_field} is a required key in insert_intent_to_file"
+              )
+          end
+        end
+      end
+
+      context 'when a required field is blank' do
+        required_fields.each do |required_field|
+          it "raises an 'ArgumentError' for missing required field" do
+            options = hash.clone
+            options[required_field] = ''
+
+            expect { service.intent_to_file.insert_intent_to_file(options) }
+              .to raise_error(
+                ArgumentError,
+                "#{required_field} cannot be empty or nil"
+              )
+          end
+        end
+      end
+
+      context 'when a required field is nil' do
+        required_fields.each do |required_field|
+          it "raises an 'ArgumentError' for missing required field" do
+            options = hash.clone
+            options[required_field] = nil
+
+            expect { service.intent_to_file.insert_intent_to_file(options) }
+              .to raise_error(
+                ArgumentError,
+                "#{required_field} cannot be empty or nil"
+              )
+          end
+        end
+      end
+    end
+  end
+
+  context 'validating condtionally required fields' do
+    context "for 'insert_intent_to_file'" do
+      hash = {
+        intent_to_file_type_code: 'hello_world',
+        participant_vet_id: 'hello_world',
+        received_date: 'hello_world',
+        submitter_application_icn_type_code: 'hello_world'
+      }
+
+      context "when a 'participant_claimant_id' is not provided" do
+        context "and the 'claimant_ssn' is not provided" do
+          it "raises an 'ArgumentError' for missing required field" do
+            options = hash.clone
+
+            expect { service.intent_to_file.insert_intent_to_file(options) }
+              .to raise_error(
+                ArgumentError,
+                "Must include either 'participant_claimant_id' or 'claimant_ssn'"
+              )
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description of change
- Adds ability to pass the `clmantSsn` attribute on the `insertIntentToFile()` service call.
- Makes the `ptcpntClmantId` attribute on the `insertIntentToFile()` service call optional.
  - BGS said that `ptcpntClmantId` is only required if the `clmantSsn` isn't provided.
- Adds specs around validating the required fields on the `insertIntentToFile()` service call

## Original issue(s)
[API-15184](https://vajira.max.gov/browse/API-15184)