### PR TITLE
Lower client read timeout to 2 minutes

### DIFF
--- a/lib/bgs/base.rb
+++ b/lib/bgs/base.rb
@@ -151,7 +151,7 @@ module BGS
         ssl_cert_file: @ssl_cert_file,
         ssl_ca_cert_file: @ssl_ca_cert,
         open_timeout: 10, # in seconds
-        read_timeout: 600, # in seconds
+        read_timeout: 120, # in seconds
         convert_request_keys_to: :none,
         ssl_verify_mode: @ssl_verify_mode.to_sym
       }


### PR DESCRIPTION
## Description of change
Upstream requests to BGS have been hanging and causing major latency issues as well as cycling on vets-api servers.  After doing some digging in DataDog, we've found that requests going through the `V0::Profile::PaymentHistoryController` and `Mobile::V0::PaymentHistoryController` (which both use the BGS service) are taking upwards of 3 minutes to complete and are backing up the workers.

We want to try lowering the timeout (currently set to 600 seconds or 10 minutes) to 120 seconds/2 minutes to see if this will take some of the load off of vets-api and improve latency.

## Additional Info / Context
Slack threads on this issue:
[One](https://dsva.slack.com/archives/CBU0KDSB1/p1652729244646429) 
[Two](https://dsva.slack.com/archives/CBU0KDSB1/p1652730373238989)
[Three](https://dsva.slack.com/archives/CBU0KDSB1/p1658868324376389)

[Postmortem](https://github.com/department-of-veterans-affairs/va.gov-team/issues/41123) from the first time this happened

## Datadog traces
![image](https://user-images.githubusercontent.com/25186448/181120113-93d48f40-3833-4453-8e9c-fc12a1a747f5.png)

![image (1)](https://user-images.githubusercontent.com/25186448/181120123-1dfc39d2-6a59-44b2-b979-313bb4e95575.png)

