### PR TITLE
Fix deprecation_toolkit warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call

### DIFF
--- a/lib/bgs/services.rb
+++ b/lib/bgs/services.rb
@@ -88,7 +88,7 @@ module BGS
 
     BGS::Services.all.each do |service|
       define_method(service.service_name) do
-        service.new @config
+        service.new **@config
       end
     end
 

--- a/lib/bgs/services.rb
+++ b/lib/bgs/services.rb
@@ -88,7 +88,7 @@ module BGS
 
     BGS::Services.all.each do |service|
       define_method(service.service_name) do
-        service.new **@config
+        service.new(**@config)
       end
     end
 

--- a/lib/bgs/services/claimant.rb
+++ b/lib/bgs/services/claimant.rb
@@ -44,8 +44,8 @@ module BGS
       validate_required_keys(required_update_flashes_fields, options, __method__.to_s)
 
       flashes = options[:flashes].map do |flash|
-        { assignedIndicator: flash[:assigned_indicator].nil? ? nil : flash[:assigned_indicator].strip,
-          flashName: flash[:flash_name].nil? ? nil : flash[:flash_name].strip }
+        { assignedIndicator: flash[:assigned_indicator]&.strip,
+          flashName: flash[:flash_name]&.strip }
       end
 
       response = request(


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/va.gov-team/issues/53974

Fix deprecation_toolkit warning: `Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call`:

```
---
test_debt_management_center/financial_status_report_service#get_pdf_with_logged_in_user_downloads_the_pdf:
- |
  DEPRECATION WARNING: /Users/holdenhinkle/.rvm/gems/ruby-2.7.6/bundler/gems/bgs-ext-b173cfba5de3/lib/bgs/services.rb:91: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
  /Users/holdenhinkle/.rvm/gems/ruby-2.7.6/bundler/gems/bgs-ext-b173cfba5de3/lib/bgs/base.rb:28: warning: The called method `initialize' is defined here
```