### PR TITLE
Bump savon 2.14.0 -> 2.15.1

### DIFF
--- a/bgs.gemspec
+++ b/bgs.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'httpclient'
   gem.add_runtime_dependency 'nokogiri', '>= 1.13.6'
-  gem.add_runtime_dependency 'savon', '~> 2.14.0'
+  gem.add_runtime_dependency 'savon', '~> 2.15.1'
   gem.add_development_dependency 'rspec', '~> 3.9.0'
   gem.add_development_dependency 'vcr', '~> 6.0.0'
   gem.add_development_dependency 'webmock', '~> 3.8.3'

--- a/bgs.gemspec
+++ b/bgs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name          = 'bgs_ext'
-  gem.version       = '0.23.0'
+  gem.version       = '0.23.1'
   gem.summary       = 'Thin wrapper on top of savon to talk with BGS'
   gem.description   = 'Thin wrapper on top of savon to talk with BGS for external BGS consumers'
   gem.license       = 'CC0' # This work is a work of the US Federal Government,


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
~~Bumping `savon` to 15.1 was necessary to bump `rack` in vets-api`. This required bumping ruby to 3.3. One of the dependencies must have included active_support, because a few errors introduced themselves, but were fixed by just including the `active_support` and requiring the respective methods as needed (slightly simpler than coming up with other solutions).~~

~~Note: The only other change that wasn't related to rubocop was using the `underscore` method instead of `snakecase`, which provides the same functionality.~~

Moved majority of work to https://github.com/department-of-veterans-affairs/bgs-ext/pull/120, so this PR now just bumps savon to 15.1

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/88401
