### PR TITLE
Remove underscore alias

### DIFF
--- a/bgs.gemspec
+++ b/bgs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name          = 'bgs_ext'
-  gem.version       = '0.23.1'
+  gem.version       = '0.23.2'
   gem.summary       = 'Thin wrapper on top of savon to talk with BGS'
   gem.description   = 'Thin wrapper on top of savon to talk with BGS for external BGS consumers'
   gem.license       = 'CC0' # This work is a work of the US Federal Government,

--- a/lib/bgs/core_ext/snakecase.rb
+++ b/lib/bgs/core_ext/snakecase.rb
@@ -9,7 +9,4 @@ class String
       .tr('-', '_')
       .downcase
   end
-
-  # add alias #underscore, as that is the proper/new active_support method name
-  alias underscore snakecase
 end

--- a/spec/bgs/core_ext/snakecase_spec.rb
+++ b/spec/bgs/core_ext/snakecase_spec.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
-require 'bgs/core_ext/blank'
-
 describe String do
   context '#snakecase' do
     it 'correctly applies the case' do
       expect('CamelCase'.snakecase).to eq 'camel_case'
-      expect('CamelCase'.underscore).to eq 'camel_case'
     end
   end
 end


### PR DESCRIPTION
## Description of change
I can't fully explain it, but the `underscore` alias of `snakecase` was interfering with the `Inflection` class/`underscore` functionality in vets-api. As this wasn't necessary in the first place, I'm just removing it. 

I tested failing vets-api specs against a local version of this branch and it seems to have fixed the errors ¯\_(ツ)_/¯

## Original issue(s)
https://github.com/department-of-veterans-affairs/bgs-ext/pull/119
