### PR TITLE
Improve mocking behavior

### DIFF
--- a/bgs.gemspec
+++ b/bgs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name          = 'bgs_ext'
-  gem.version       = '0.23.2'
+  gem.version       = '0.23.3'
   gem.summary       = 'Thin wrapper on top of savon to talk with BGS'
   gem.description   = 'Thin wrapper on top of savon to talk with BGS for external BGS consumers'
   gem.license       = 'CC0' # This work is a work of the US Federal Government,

--- a/lib/bgs/base.rb
+++ b/lib/bgs/base.rb
@@ -167,8 +167,6 @@ module BGS
         # If mocking, we fall back to using the external_uid.
         file_path = generate_mock_filepath(method, identifier || @external_uid)
 
-        raise "Mock response file not found: #{file_path}" unless File.exist?(file_path)
-
         Struct.new(:body).new(JSON.parse(File.read(file_path), symbolize_names: true))
       else
         client.call(method, message: message)
@@ -188,10 +186,10 @@ module BGS
       file_path = "#{directory}#{identifier}.json"
       default_file_path = "#{directory}default.json"
 
-      # fallback to default if specific file does not exist
-      file_path = default_file_path if !File.exist?(file_path) && File.exist?(default_file_path)
+      # raise an error if neither specific nor default mock exists
+      raise "Mock response file not found: #{file_path}" unless File.exist?(file_path) || File.exist?(default_file_path)
 
-      file_path
+      File.exist?(file_path) ? file_path : default_file_path
     end
 
     def handle_request_error(error)

--- a/lib/bgs/base.rb
+++ b/lib/bgs/base.rb
@@ -186,9 +186,10 @@ module BGS
     def generate_mock_filepath(method, identifier)
       directory = "#{BGS.configuration.mock_response_location}/#{@service_name.snakecase}/#{method}/"
       file_path = "#{directory}#{identifier}.json"
+      default_file_path = "#{directory}default.json"
 
       # fallback to default if specific file does not exist
-      file_path = "#{directory}default.json" unless File.exist?(file_path)
+      file_path = default_file_path if !File.exist?(file_path) && File.exist?(default_file_path)
 
       file_path
     end

--- a/lib/bgs/base.rb
+++ b/lib/bgs/base.rb
@@ -163,11 +163,16 @@ module BGS
     # Proxy to call a method on our web service.
     def request(method, message = nil, identifier = nil)
       if mock_responses
-        raise "No identifier for mock response" if identifier.nil?
+        # Many services don't allow passing a separate identifier parameter.
+        # If mocking, we fall back to using the external_uid.
+        file_path = generate_mock_filepath(method, identifier || @external_uid)
 
-        file_path = BGS.configuration.mock_response_location
-        file_path += "/#{@service_name.underscore}/#{method}/#{identifier}.json"
-        Struct.new(:body).new(JSON.parse(File.read(file_path)).with_indifferent_access)
+        # If the file doesn't exist, use the 'default' identifier
+        file_path = generate_mock_filepath(method, 'default') unless File.exist?(file_path)
+
+        raise "Mock response file not found: #{file_path}" unless File.exist?(file_path)
+
+        Struct.new(:body).new(JSON.parse(File.read(file_path), symbolize_names: true))
       else
         client.call(method, message: message)
       end
@@ -179,6 +184,10 @@ module BGS
       handle_request_error(error)
     rescue Errno::ENOENT => error
       puts error
+    end
+
+    def generate_mock_filepath(method, identifier)
+      "#{BGS.configuration.mock_response_location}/#{@service_name.snakecase}/#{method}/#{identifier}.json"
     end
 
     def handle_request_error(error)

--- a/lib/bgs/base.rb
+++ b/lib/bgs/base.rb
@@ -167,9 +167,6 @@ module BGS
         # If mocking, we fall back to using the external_uid.
         file_path = generate_mock_filepath(method, identifier || @external_uid)
 
-        # If the file doesn't exist, use the 'default' identifier
-        file_path = generate_mock_filepath(method, 'default') unless File.exist?(file_path)
-
         raise "Mock response file not found: #{file_path}" unless File.exist?(file_path)
 
         Struct.new(:body).new(JSON.parse(File.read(file_path), symbolize_names: true))
@@ -187,7 +184,13 @@ module BGS
     end
 
     def generate_mock_filepath(method, identifier)
-      "#{BGS.configuration.mock_response_location}/#{@service_name.snakecase}/#{method}/#{identifier}.json"
+      directory = "#{BGS.configuration.mock_response_location}/#{@service_name.snakecase}/#{method}/"
+      file_path = "#{directory}#{identifier}.json"
+
+      # fallback to default if specific file does not exist
+      file_path = "#{directory}default.json" unless File.exist?(file_path)
+
+      file_path
     end
 
     def handle_request_error(error)

--- a/spec/bgs/base_spec.rb
+++ b/spec/bgs/base_spec.rb
@@ -289,7 +289,7 @@ describe BGS::Base do
 
       context 'and no mock file exists at all' do
         it 'raises an error with the expected file path' do
-          expected_default_path = "#{mock_location}/test_base/#{mock_method}/default.json"
+          expected_default_path = "#{mock_location}/test_base/#{mock_method}/test_user_123.json"
           expect do
             mock_base.test_request(mock_method)
           end.to raise_error(RuntimeError, "Mock response file not found: #{expected_default_path}")
@@ -297,8 +297,12 @@ describe BGS::Base do
 
         it 'includes both the identifier-specific and default paths in the error flow' do
           # First it tries with the identifier, then with 'default', then raises
-          expect(File).to receive(:exist?).with("#{mock_location}/test_base/#{mock_method}/test_user_123.json").and_return(false)
-          expect(File).to receive(:exist?).with("#{mock_location}/test_base/#{mock_method}/default.json").and_return(false)
+          expect(File).to receive(:exist?).with(
+            "#{mock_location}/test_base/#{mock_method}/test_user_123.json"
+          ).and_return(false).at_least(:once)
+          expect(File).to receive(:exist?).with(
+            "#{mock_location}/test_base/#{mock_method}/default.json"
+          ).and_return(false)
 
           expect do
             mock_base.test_request(mock_method)

--- a/spec/bgs/base_spec.rb
+++ b/spec/bgs/base_spec.rb
@@ -209,14 +209,149 @@ describe BGS::Base do
       expect(@log_out.string).to match(/I, \[.+\]  INFO -- /)
     end
   end
+
+  context 'mock responses' do
+    let(:mock_base) do
+      BGS::TestBase.new(
+        env: 'beplinktest',
+        application: 'TEST_APP',
+        client_ip: '127.0.0.1',
+        client_station_id: 283,
+        client_username: 'VACOUSERT',
+        external_uid: 'test_user_123',
+        external_key: 'test_key',
+        mock_responses: true
+      )
+    end
+    let(:mock_location) { '/tmp/bgs_mocks' }
+    let(:mock_method) { :find_person }
+    let(:mock_data) { { person_id: '12345', first_name: 'John', last_name: 'Doe' } }
+
+    before do
+      BGS.configure do |config|
+        @old_mock_location = config.mock_response_location
+        config.mock_response_location = mock_location
+      end
+    end
+
+    after do
+      BGS.configure do |config|
+        config.mock_response_location = @old_mock_location
+      end
+      FileUtils.rm_rf(mock_location)
+    end
+
+    context 'when mock_responses is enabled' do
+      context 'and a mock file exists for the identifier' do
+        before do
+          mock_file_path = "#{mock_location}/test_base/#{mock_method}/test_user_123.json"
+          FileUtils.mkdir_p(File.dirname(mock_file_path))
+          File.write(mock_file_path, mock_data.to_json)
+        end
+
+        it 'returns the mocked response from the file' do
+          response = mock_base.test_request(mock_method)
+          expect(response.body).to eq(mock_data)
+        end
+
+        it 'does not call the Savon client' do
+          expect_any_instance_of(Savon::Client).not_to receive(:call)
+          mock_base.test_request(mock_method)
+        end
+      end
+
+      context 'and a mock file exists with a custom identifier' do
+        let(:custom_identifier) { 'custom_id_456' }
+        before do
+          mock_file_path = "#{mock_location}/test_base/#{mock_method}/#{custom_identifier}.json"
+          FileUtils.mkdir_p(File.dirname(mock_file_path))
+          File.write(mock_file_path, mock_data.to_json)
+        end
+
+        it 'returns the mocked response using the custom identifier' do
+          response = mock_base.test_request(mock_method, nil, custom_identifier)
+          expect(response.body).to eq(mock_data)
+        end
+      end
+
+      context 'and no mock file exists for the identifier but a default exists' do
+        before do
+          mock_file_path = "#{mock_location}/test_base/#{mock_method}/default.json"
+          FileUtils.mkdir_p(File.dirname(mock_file_path))
+          File.write(mock_file_path, mock_data.to_json)
+        end
+
+        it 'falls back to the default mock file' do
+          response = mock_base.test_request(mock_method)
+          expect(response.body).to eq(mock_data)
+        end
+      end
+
+      context 'and no mock file exists at all' do
+        it 'raises an error with the expected file path' do
+          expected_default_path = "#{mock_location}/test_base/#{mock_method}/default.json"
+          expect do
+            mock_base.test_request(mock_method)
+          end.to raise_error(RuntimeError, "Mock response file not found: #{expected_default_path}")
+        end
+
+        it 'includes both the identifier-specific and default paths in the error flow' do
+          # First it tries with the identifier, then with 'default', then raises
+          expect(File).to receive(:exist?).with("#{mock_location}/test_base/#{mock_method}/test_user_123.json").and_return(false)
+          expect(File).to receive(:exist?).with("#{mock_location}/test_base/#{mock_method}/default.json").and_return(false)
+
+          expect do
+            mock_base.test_request(mock_method)
+          end.to raise_error(RuntimeError, /Mock response file not found/)
+        end
+      end
+    end
+
+    context 'generate_mock_filepath' do
+      it 'generates the correct file path for a given method and identifier' do
+        expected_path = "#{mock_location}/test_base/#{mock_method}/test_user_123.json"
+        actual_path = mock_base.send(:generate_mock_filepath, mock_method, 'test_user_123')
+        expect(actual_path).to eq(expected_path)
+      end
+
+      it 'generates the correct file path for the default identifier' do
+        expected_path = "#{mock_location}/test_base/#{mock_method}/default.json"
+        actual_path = mock_base.send(:generate_mock_filepath, mock_method, 'default')
+        expect(actual_path).to eq(expected_path)
+      end
+    end
+
+    context 'when mock_responses is disabled' do
+      let(:non_mock_base) do
+        BGS::TestBase.new(
+          env: 'beplinktest',
+          application: 'TEST_APP',
+          client_ip: '127.0.0.1',
+          client_station_id: 283,
+          client_username: 'VACOUSERT',
+          external_uid: 'test_user_123',
+          external_key: 'test_key',
+          mock_responses: false
+        )
+      end
+
+      it 'calls the Savon client instead of reading from file' do
+        allow_any_instance_of(Savon::Client).to receive(:call).and_return(
+          Struct.new(:body).new(mock_data)
+        )
+        expect_any_instance_of(Savon::Client).to receive(:call).with(mock_method, message: nil)
+        non_mock_base.test_request(mock_method)
+      end
+    end
+  end
 end
 # rubocop:enable Metrics/BlockLength
 
 # Helper class to allow us to test BGS::Base's private request() method.
 module BGS
   class TestBase < BGS::Base
-    def test_request(method, message = nil)
-      request(method, message)
+    def test_request(method, message = nil, identifier = nil)
+      request(method, message, identifier)
     end
   end
 end

--- a/spec/bgs/base_spec.rb
+++ b/spec/bgs/base_spec.rb
@@ -321,6 +321,7 @@ describe BGS::Base do
 
       it 'generates the correct file path for the default identifier' do
         expected_path = "#{mock_location}/test_base/#{mock_method}/default.json"
+        allow(File).to receive(:exist?).with(expected_path).and_return(true)
         actual_path = mock_base.send(:generate_mock_filepath, mock_method, 'default')
         expect(actual_path).to eq(expected_path)
       end

--- a/spec/bgs/base_spec.rb
+++ b/spec/bgs/base_spec.rb
@@ -310,6 +310,7 @@ describe BGS::Base do
     context 'generate_mock_filepath' do
       it 'generates the correct file path for a given method and identifier' do
         expected_path = "#{mock_location}/test_base/#{mock_method}/test_user_123.json"
+        allow(File).to receive(:exist?).with(expected_path).and_return(true)
         actual_path = mock_base.send(:generate_mock_filepath, mock_method, 'test_user_123')
         expect(actual_path).to eq(expected_path)
       end


### PR DESCRIPTION
## Description of change
This pull request improves the mocking infrastructure for BGS service calls, making it more robust and flexible. The changes include a refactor of how mock response files are located and loaded, enhanced fallback logic, and comprehensive tests to ensure correct behavior.

**Enhancements to mocking and file path generation:**
- Refactored the `request` method in `lib/bgs/base.rb` to use a new `generate_mock_filepath` helper for constructing mock response file paths, and added fallback logic to use a `default.json` file if a specific identifier file does not exist. The method now also parses JSON with symbolized names for consistency.
- Added the `generate_mock_filepath` private method to encapsulate the logic for building the mock file path, improving maintainability and testability.

**Testing improvements:**
- Added extensive new tests in `spec/bgs/base_spec.rb` to cover various mock response scenarios, including: using the correct identifier, falling back to a default file, handling missing files gracefully, and verifying that the Savon client is not called when mocking is enabled. Also includes tests for the new file path generation logic.

**Versioning:**
- Bumped the gem version to `0.23.3` in `bgs.gemspec` to reflect these improvements.

Replaces https://github.com/department-of-veterans-affairs/bgs-ext/pull/124

## Testing

- Set vets-api to use a local version of bgs-ext set to this branch, then tested various BGS services using `mock` and confirmed the identifier and default responses were returned
- Also added tests for the change